### PR TITLE
Interrupt

### DIFF
--- a/intel_mraa_interrupt_gpio_block.py
+++ b/intel_mraa_interrupt_gpio_block.py
@@ -1,0 +1,33 @@
+import mraa
+from nio.common.signal.base import Signal
+from nio.common.discovery import Discoverable, DiscoverableType
+from .intel_mraa_gpio_base import IntelMraaGpioBase
+
+
+def interrupt_callback(self):
+    self._logger.debug("Executing interrupt callback")
+    pin_number = self.mraa_gpio_pin
+    pin_value = self._gpio_pin.read()
+    self._logger.debug("Mraa pin # {} is now {}".format(pin_number, pin_value))
+    self.notify_signals([Signal({"pin_value": pin_value,
+                                 "pin_number": pin_number})])
+
+
+@Discoverable(DiscoverableType.block)
+class IntelMraaInterruptGpio(IntelMraaGpioBase):
+
+    """ Use Intel's libmraa to interface with the IO on various platforms """
+
+    def configure(self, context):
+        super().configure(context)
+        # TODO: make EDGE_BOTH configurable
+        self._gpio_pin.isr(mraa.EDGE_BOTH, interrupt_callback, self)
+        self._logger.debug(
+            "Configured mraa pin # {} interrupt".format(self.mraa_gpio_pin))
+
+    def _pin_mode(self):
+        return mraa.DIR_IN
+
+    def process_signals(self, signals, input_id='default'):
+        # This block should not respond to input signals
+        pass

--- a/tests/test_intel_mraa_interrupt_gpio_block.py
+++ b/tests/test_intel_mraa_interrupt_gpio_block.py
@@ -2,40 +2,39 @@ from collections import defaultdict
 from nio.common.signal.base import Signal
 from nio.util.support.block_test_case import NIOBlockTestCase
 #from unittest import skipUnless
-#from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 from ..intel_mraa_interrupt_gpio_block import IntelMraaInterruptGpio, interrupt_callback
 
 class TestIntelMraaInterruptGpio(NIOBlockTestCase):
-
+    
     def setUp(self):
         super().setUp()
         # This will keep a list of signals notified for each output
         self.last_notified = defaultdict(list)
-
+    
     def signals_notified(self, signals, output_id='default'):
         self.last_notified[output_id].extend(signals)
-
+    
     def test_pass(self):
         pass
     
-    #@patch('mraa.Gpio')
-    def test_defaults(self):
-        blk = IntelMraaGpioInterrupt()
+    @patch('mraa.Gpio')
+    def test_defaults(self, mock_mraa_gpio):
+        blk = IntelMraaInterruptGpio()
         self.configure_block(blk, {})
         blk.start()
         blk.process_signals([Signal()])
         blk.stop()
         self.assert_num_signals_notified(0)
     
-    #@patch('mraa.Gpio')
-    def test_interrupt(self):
-        blk = IntelMraaGpioInterrupt()
+    @patch('mraa.Gpio')
+    def test_interrupt(self, mock_mraa_gpio):
+        blk = IntelMraaInterruptGpio()
         self.configure_block(blk, {})
         blk.start()
+        blk._gpio_pin.read = MagicMock(return_value = 1)
         interrupt_callback(blk)
-        #TODO: trigger callback somehow
         blk.stop()
         self.assert_num_signals_notified(1)
-        [Signal()])
-        self.assertDictEqual(self.last_notified['default'][0].to_dict(), {"pin_value": 0,
-                        "pin_number": 10})
+        self.assertDictEqual(self.last_notified['default'][0].to_dict(), {"pin_value": 1,
+                             "pin_number": '31'})

--- a/tests/test_intel_mraa_interrupt_gpio_block.py
+++ b/tests/test_intel_mraa_interrupt_gpio_block.py
@@ -1,0 +1,41 @@
+from collections import defaultdict
+from nio.common.signal.base import Signal
+from nio.util.support.block_test_case import NIOBlockTestCase
+#from unittest import skipUnless
+#from unittest.mock import MagicMock, patch
+from ..intel_mraa_interrupt_gpio_block import IntelMraaInterruptGpio, interrupt_callback
+
+class TestIntelMraaInterruptGpio(NIOBlockTestCase):
+
+    def setUp(self):
+        super().setUp()
+        # This will keep a list of signals notified for each output
+        self.last_notified = defaultdict(list)
+
+    def signals_notified(self, signals, output_id='default'):
+        self.last_notified[output_id].extend(signals)
+
+    def test_pass(self):
+        pass
+    
+    #@patch('mraa.Gpio')
+    def test_defaults(self):
+        blk = IntelMraaGpioInterrupt()
+        self.configure_block(blk, {})
+        blk.start()
+        blk.process_signals([Signal()])
+        blk.stop()
+        self.assert_num_signals_notified(0)
+    
+    #@patch('mraa.Gpio')
+    def test_interrupt(self):
+        blk = IntelMraaGpioInterrupt()
+        self.configure_block(blk, {})
+        blk.start()
+        interrupt_callback(blk)
+        #TODO: trigger callback somehow
+        blk.stop()
+        self.assert_num_signals_notified(1)
+        [Signal()])
+        self.assertDictEqual(self.last_notified['default'][0].to_dict(), {"pin_value": 0,
+                        "pin_number": 10})

--- a/tests/test_intel_mraa_interrupt_gpio_block.py
+++ b/tests/test_intel_mraa_interrupt_gpio_block.py
@@ -1,10 +1,17 @@
 from collections import defaultdict
 from nio.common.signal.base import Signal
 from nio.util.support.block_test_case import NIOBlockTestCase
-#from unittest import skipUnless
+from unittest import skipUnless
 from unittest.mock import MagicMock, patch
-from ..intel_mraa_interrupt_gpio_block import IntelMraaInterruptGpio, interrupt_callback
 
+
+mraa_available = True
+try:
+    from ..intel_mraa_interrupt_gpio_block import IntelMraaInterruptGpio, interrupt_callback
+except:
+    mraa_available = False
+
+@skipUnless(mraa_available, 'mraa is not available!!')
 class TestIntelMraaInterruptGpio(NIOBlockTestCase):
     
     def setUp(self):

--- a/tests/test_intel_mraa_read_gpio_block.py
+++ b/tests/test_intel_mraa_read_gpio_block.py
@@ -1,11 +1,17 @@
 from collections import defaultdict
 from nio.common.signal.base import Signal
 from nio.util.support.block_test_case import NIOBlockTestCase
-#from unittest import skipUnless
+from unittest import skipUnless
 from unittest.mock import MagicMock, patch
-from ..intel_mraa_read_gpio_block import IntelMraaReadGpio
 
 
+mraa_available = True
+try:
+    from ..intel_mraa_interrupt_gpio_block import IntelMraaReadGpio
+except:
+    mraa_available = False
+
+@skipUnless(mraa_available, 'mraa is not available!!')
 class TestIntelMraaReadGpio(NIOBlockTestCase):
 
     def setUp(self):

--- a/tests/test_intel_mraa_read_gpio_block.py
+++ b/tests/test_intel_mraa_read_gpio_block.py
@@ -1,6 +1,8 @@
 from collections import defaultdict
 from nio.common.signal.base import Signal
 from nio.util.support.block_test_case import NIOBlockTestCase
+#from unittest import skipUnless
+from unittest.mock import MagicMock, patch
 from ..intel_mraa_read_gpio_block import IntelMraaReadGpio
 
 
@@ -16,12 +18,14 @@ class TestIntelMraaReadGpio(NIOBlockTestCase):
 
     def test_pass(self):
         pass
-
-    def test_defaults(self):
-        blk = IntelMraaGpioRead()
+    
+    @patch('mraa.Gpio')
+    def test_defaults(self, mock_mraa_gpio):
+        blk = IntelMraaReadGpio()
         self.configure_block(blk, {})
         blk.start()
+        blk._gpio_pin.read = MagicMock(return_value = 1)
         blk.process_signals([Signal()])
         blk.stop()
         self.assert_num_signals_notified(1)
-        self.assertDictEqual(self.last_notified['default'][0].to_dict(), {})
+        self.assertDictEqual(self.last_notified['default'][0].to_dict(), {"pin": 1})

--- a/tests/test_intel_mraa_read_gpio_block.py
+++ b/tests/test_intel_mraa_read_gpio_block.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 
 mraa_available = True
 try:
-    from ..intel_mraa_interrupt_gpio_block import IntelMraaReadGpio
+    from ..intel_mraa_read_gpio_block import IntelMraaReadGpio
 except:
     mraa_available = False
 

--- a/tests/test_intel_mraa_write_gpio_block.py
+++ b/tests/test_intel_mraa_write_gpio_block.py
@@ -1,11 +1,17 @@
 from collections import defaultdict
 from nio.common.signal.base import Signal
 from nio.util.support.block_test_case import NIOBlockTestCase
-#from unittest import skipUnless
+from unittest import skipUnless
 from unittest.mock import MagicMock, patch
-from ..intel_mraa_write_gpio_block import IntelMraaWriteGpio
 
 
+mraa_available = True
+try:
+    from ..intel_mraa_interrupt_gpio_block import IntelMraaWriteGpio
+except:
+    mraa_available = False
+
+@skipUnless(mraa_available, 'mraa is not available!!')
 class TestIntelMraaWriteGpio(NIOBlockTestCase):
 
     def setUp(self):

--- a/tests/test_intel_mraa_write_gpio_block.py
+++ b/tests/test_intel_mraa_write_gpio_block.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 
 mraa_available = True
 try:
-    from ..intel_mraa_interrupt_gpio_block import IntelMraaWriteGpio
+    from ..intel_mraa_write_gpio_block import IntelMraaWriteGpio
 except:
     mraa_available = False
 

--- a/tests/test_intel_mraa_write_gpio_block.py
+++ b/tests/test_intel_mraa_write_gpio_block.py
@@ -1,6 +1,8 @@
 from collections import defaultdict
 from nio.common.signal.base import Signal
 from nio.util.support.block_test_case import NIOBlockTestCase
+#from unittest import skipUnless
+from unittest.mock import MagicMock, patch
 from ..intel_mraa_write_gpio_block import IntelMraaWriteGpio
 
 
@@ -16,12 +18,14 @@ class TestIntelMraaWriteGpio(NIOBlockTestCase):
 
     def test_pass(self):
         pass
-
-    def test_defaults(self):
-        blk = IntelMraaGpioWrite()
+    
+    @patch('mraa.Gpio')
+    def test_defaults(self, mock_mraa_gpio):
+        blk = IntelMraaWriteGpio()
         self.configure_block(blk, {})
         blk.start()
+        blk._gpio_pin.write = MagicMock(return_value = 'Test Write Status')
         blk.process_signals([Signal()])
         blk.stop()
         self.assert_num_signals_notified(1)
-        self.assertDictEqual(self.last_notified['default'][0].to_dict(), {})
+        self.assertDictEqual(self.last_notified['default'][0].to_dict(), {"write_status": 'Test Write Status'})


### PR DESCRIPTION
Added GPIO Interrupt block.
Basic unit tests now working for all 3 blocks (read, write, interrupt). 
Added skip statement to unit tests for when library "mraa" is not available.

Fix #5 
